### PR TITLE
Fix out-of-bounds index in utils

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -227,7 +227,8 @@ export function getDocumentTimestampByIndex(
   index: number,
 ) {
   if (!documents) return new Date();
-  if (index > documents.length) return new Date();
+  // Guard against out-of-bounds access
+  if (index < 0 || index >= documents.length) return new Date();
 
   return documents[index].createdAt;
 }


### PR DESCRIPTION
## Summary
- prevent out-of-bounds access in `getDocumentTimestampByIndex`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683ff82929a483239bfcf912aab92b9f